### PR TITLE
ko. reference fix for selectextns

### DIFF
--- a/helpers/jasmine-13-helper.js
+++ b/helpers/jasmine-13-helper.js
@@ -104,7 +104,7 @@ matchers.toHaveValues = function (expectedValues) {
 
 matchers.toHaveSelectedValues = function (expectedValues) {
     var selectedNodes = arrayFilter(this.actual.childNodes, function (node) { return node.selected; }),
-        selectedValues = arrayMap(selectedNodes, function (node) { return ko.selectExtensions.readValue(node); });
+        selectedValues = arrayMap(selectedNodes, function (node) { return this.selectExtensions.readValue(node); });
     this.actual = selectedValues;   // Fix explanatory message
     return this.env.equals_(selectedValues, expectedValues);
 };


### PR DESCRIPTION
reference to ko.select\* was causing error in tko.binding.core. fixing it.
